### PR TITLE
Privileged users

### DIFF
--- a/windapsearch.py
+++ b/windapsearch.py
@@ -25,21 +25,15 @@ FUNCTIONALITYLEVELS = {
 	"7": "2016"
 }
 
-PROTECTED_GROUPS = {
-    "Account Operators",
-    "Backup Operators",
-    "Print Operators",
-    "Server Operators",
-    "Administrators",
-    "Domain Admins",
-    "Schema Admins",
-    "Enterprise Admins",
-    "Enterprise Key Admins",
-    "Key Admins",
-    "Domain Controllers",
-    "Read-only Domain Controllers",
-    "Replicator"
-}
+# Privileged builtin AD groups relevant to look for 
+BUILTIN_PRIVILEGED_GROUPS = [
+	"Administrators",		#Builtin administrators group for the domain
+	"Domain Admins",		# ''
+	"Enterprise Admins",	# ''
+	"Schema Admins",		#Highly privileged builtin group
+	"Account Operators",	# ''
+	"Backup Operators"		# ''
+]
 
 class LDAPSearchResult(object):
 	"""A helper class to work with raw search results
@@ -589,7 +583,7 @@ def run(args):
 
 	if args.privileged_users:
 		print "[+] Attempting to enumerate all AD privileged users"
-		for group in PROTECTED_GROUPS:
+		for group in BUILTIN_PRIVILEGED_GROUPS:
 			daDN = "CN={},CN=Users,{}".format(group,ldapSession.domainBase)
 			print "[+] Using DN: {}".format(daDN)
 			domainAdminResults, searchAttrs = ldapSession.getNestedGroupMemberships(daDN, attrs=attrs)

--- a/windapsearch.py
+++ b/windapsearch.py
@@ -25,6 +25,22 @@ FUNCTIONALITYLEVELS = {
 	"7": "2016"
 }
 
+PROTECTED_GROUPS = {
+    "Account Operators",
+    "Backup Operators",
+    "Print Operators",
+    "Server Operators",
+    "Administrators",
+    "Domain Admins",
+    "Schema Admins",
+    "Enterprise Admins",
+    "Enterprise Key Admins",
+    "Key Admins",
+    "Domain Controllers",
+    "Read-only Domain Controllers",
+    "Replicator"
+}
+
 class LDAPSearchResult(object):
 	"""A helper class to work with raw search results
 	Copied from here: https://www.packtpub.com/books/content/configuring-and-securing-python-ldap-applications-part-2
@@ -571,6 +587,18 @@ def run(args):
 			filename = "{}/{}-users.tsv".format(args.output_dir, startTime)
 			writeResults(allUsers, searchAttrs, filename)
 
+	if args.privileged_users:
+		print "[+] Attempting to enumerate all AD privileged users"
+		for group in PROTECTED_GROUPS:
+			daDN = "CN={},CN=Users,{}".format(group,ldapSession.domainBase)
+			print "[+] Using DN: {}".format(daDN)
+			domainAdminResults, searchAttrs = ldapSession.getNestedGroupMemberships(daDN, attrs=attrs)
+			print "[+]\tFound {} nested users for group {}:\n".format(len(domainAdminResults),group)
+			prettyPrintResults(domainAdminResults)
+			if args.output_dir:
+				filename = "{}/{}-{}-users.tsv".format(args.output_dir, startTime, group.replace(" ","_"))
+				writeResults(domainAdminResults, searchAttrs, filename)
+
 	if args.computers:
 		print "\n[+] Enumerating all AD computers"
 		allComputers, searchAttrs = ldapSession.getAllComputers(attrs=attrs)
@@ -749,6 +777,7 @@ if __name__ == '__main__':
 	egroup.add_argument("--functionality", action="store_true", help="Enumerate Domain Functionality level. Possible through anonymous bind")
 	egroup.add_argument("-G", "--groups", action="store_true", help="Enumerate all AD Groups")
 	egroup.add_argument("-U", "--users", action="store_true", help="Enumerate all AD Users")
+	egroup.add_argument("-PU", "--privileged-users", dest="privileged_users", action="store_true", help="Enumerate All privileged AD Users. Performs recursive lookups for nested members.")
 	egroup.add_argument("-C", "--computers", action="store_true", help="Enumerate all AD Computers")
 	egroup.add_argument("-m", "--members", metavar="GROUP_NAME", dest="group_name", type=str, help="Enumerate all members of a group")
 	egroup.add_argument("--da", action="store_true", help="Shortcut for enumerate all members of group 'Domain Admins'. Performs recursive lookups for nested members.")

--- a/windapsearch.py
+++ b/windapsearch.py
@@ -27,12 +27,12 @@ FUNCTIONALITYLEVELS = {
 
 # Privileged builtin AD groups relevant to look for 
 BUILTIN_PRIVILEGED_GROUPS = [
-	"Administrators",		#Builtin administrators group for the domain
-	"Domain Admins",		# ''
-	"Enterprise Admins",	# ''
-	"Schema Admins",		#Highly privileged builtin group
-	"Account Operators",	# ''
-	"Backup Operators"		# ''
+	"Administrators",      #Builtin administrators group for the domain
+	"Domain Admins",       # ''
+	"Enterprise Admins",   # ''
+	"Schema Admins",       #Highly privileged builtin group
+	"Account Operators",   # ''
+	"Backup Operators"     # ''
 ]
 
 class LDAPSearchResult(object):


### PR DESCRIPTION
Hello,
I added the research for nested members for the following groups:

```
BUILTIN_PRIVILEGED_GROUPS = [
	"Administrators",         #Builtin administrators group for the domain
	"Domain Admins",       # ''
	"Enterprise Admins",   # ''
	"Schema Admins",       #Highly privileged builtin group
	"Account Operators",   # ''
	"Backup Operators"     # ''
]
```

Why ?:
- we are looking for privileged users (here dealing with builtin privileged groups), crossing the results with other findings
- we are avoiding false positive with users having set admin_count=1 and not belonging anymore to any  protected groups.

Cheers. 