### PR TITLE
Made domain part optional in username

### DIFF
--- a/windapsearch.py
+++ b/windapsearch.py
@@ -529,7 +529,10 @@ def run(args):
         password = ''
         print("[+] No username provided. Will try anonymous bind.")
     else:
-        username = args.username
+        if not '\\' in args.username:
+            username = args.domain + '\\' + args.username
+        else:
+            username = args.username
 
     if args.username and not args.password:
         password = getpass.getpass("Password for {}: ".format(args.username))


### PR DESCRIPTION
I find that that the domain info is redundant in the _username_ option as it is already supplied in the _domain_ option.
So, this PR will allow domain info to be optional in the _username_ and if the user has not supplied it then the value specified in the _domain_ option will be appended to the username behind the scene.

This will allow both the commands to work seamlessly:

```bash
python3 windapsearch.py -d MyDomain -u MyDomain\\sam -C 
python3 windapsearch.py -d MyDomain -u sam -C 
```
