### PR TITLE
Fix resolve IP feature

### DIFF
--- a/windapsearch.py
+++ b/windapsearch.py
@@ -379,7 +379,7 @@ class LDAPSession(object):
             computerInfo = {}
             dn = computer.dn
             for attr in computer.get_attr_names():
-                computerInfo[attr] = ','.join(computer.get_attr_values(attr))
+                computerInfo[attr] = ','.join([val.decode() for val in computer.get_attr_values(attr)])
 
             if 'dNSHostName' in computerInfo:
                 hostname = computerInfo['dNSHostName']
@@ -489,7 +489,7 @@ def prettyPrintDictionary(results, attrs=None, separator=","):
                     'operatingSystemServicePack']
     attrs = []
 
-    for dn, computer in results.iteritems():
+    for dn, computer in results.items():
         for key in computer:
             keys.add(key)
 

--- a/windapsearch.py
+++ b/windapsearch.py
@@ -32,6 +32,8 @@ DOMAIN_ADMIN_GROUPS = [
     "Domain-Admins",
     "Domänen Administratoren",
     "Domänen-Administratoren",
+    "Администраторы домена",
+    "Администраторы-домена",
 ]
 
 # Privileged builtin AD groups relevant to look for


### PR DESCRIPTION
Hi @ropnop!

In this PR I would like to bring a fix for the `--resolve` switch. Currently using the resolve IP feature breaks the script due to a type error:

```python
$ python3 windapsearch.py --dc-ip 127.0.0.1 -d corp.local -u '' -C -r > windapsearch.out
Traceback (most recent call last):
  File "/home/snovvcrash/tools/windapsearch/windapsearch.py", line 825, in <module>
    run(args)
  File "/home/snovvcrash/tools/windapsearch/windapsearch.py", line 610, in run
    allComputersDict = ldapSession.getComputerDict(allComputers, ipLookup=True)
  File "/home/snovvcrash/tools/windapsearch/windapsearch.py", line 380, in getComputerDict
    computerInfo[attr] = ','.join(computer.get_attr_values(attr))
TypeError: sequence item 0: expected str instance, bytes found
```

The `ipLookup` argument in `getComputerDict` does not seem to be used as well, but I left it as is.

Also I've added a cyrillic name for Domain Admins group in this PR.